### PR TITLE
Drg only creates http verb found in swagger/feature/ch1162/loganripplinger

### DIFF
--- a/data_resource/generator/api_manager/api_generator.py
+++ b/data_resource/generator/api_manager/api_generator.py
@@ -57,15 +57,15 @@ def generate_rest_api_routes(
 
     for idx, route in enumerate(resources):
         try:
-            api.add_resource(
-                resource_api,
-                route,
-                endpoint=f"{resource_name}_ep_{idx}",
-                methods=enabled_routes[route],
-            )
+            methods = enabled_routes[route]
         except KeyError:
             logger.warning(
                 f"Route '{route}' not found in swagger. Therefore it is disabled. This may cause errors."
             )
+            continue
+
+        api.add_resource(
+            resource_api, route, endpoint=f"{resource_name}_ep_{idx}", methods=methods
+        )
 
     return resources

--- a/data_resource/generator/api_manager/api_generator.py
+++ b/data_resource/generator/api_manager/api_generator.py
@@ -56,11 +56,16 @@ def generate_rest_api_routes(
     )
 
     for idx, route in enumerate(resources):
-        api.add_resource(
-            resource_api,
-            route,
-            endpoint=f"{resource_name}_ep_{idx}",
-            methods=enabled_routes[route],
-        )
+        try:
+            api.add_resource(
+                resource_api,
+                route,
+                endpoint=f"{resource_name}_ep_{idx}",
+                methods=enabled_routes[route],
+            )
+        except KeyError:
+            logger.warning(
+                f"Route '{route}' not found in swagger. Therefore it is disabled. This may cause errors."
+            )
 
     return resources

--- a/data_resource/generator/api_manager/api_generator.py
+++ b/data_resource/generator/api_manager/api_generator.py
@@ -7,9 +7,16 @@ from data_resource.logging import LogFactory
 logger = LogFactory.get_console_logger("generator:api-generator")
 
 
+def get_enabled_routes_for_orm(resource_orm: object, swagger: dict) -> dict:
+    """Given a resource orm (name) and a swagger spec, get all enabled
+    routes."""
+    return {}
+
+
 def generate_api(base=None, swagger: dict = None, api=None) -> None:
     # Generate REST API for resources
     for resource_orm in base.classes:
+        enabled_routes = get_enabled_routes_for_orm(resource_orm, swagger)
         generate_rest_api_routes(api, resource_orm)
 
     # TODO Generate x:x REST API

--- a/data_resource/generator/api_manager/api_generator.py
+++ b/data_resource/generator/api_manager/api_generator.py
@@ -34,12 +34,14 @@ def generate_api(base=None, swagger: dict = None, api=None) -> None:
     # Generate REST API for resources
     for resource_orm in base.classes:
         enabled_routes = get_enabled_routes_for_orm(resource_orm, swagger)
-        generate_rest_api_routes(api, resource_orm)
+        generate_rest_api_routes(api, resource_orm, enabled_routes)
 
     # TODO Generate x:x REST API
 
 
-def generate_rest_api_routes(api: Api, resource_orm: DeclarativeMeta) -> None:
+def generate_rest_api_routes(
+    api: Api, resource_orm: DeclarativeMeta, enabled_routes: dict
+) -> None:
     resource_name = resource_orm.__name__.lower()
     resources = [
         f"/{resource_name}",

--- a/data_resource/generator/api_manager/api_generator.py
+++ b/data_resource/generator/api_manager/api_generator.py
@@ -2,15 +2,32 @@ from data_resource.generator.api_manager import VersionedResource
 from flask_restful import Api
 from sqlalchemy.ext.declarative import DeclarativeMeta
 from data_resource.logging import LogFactory
+import re
 
 
 logger = LogFactory.get_console_logger("generator:api-generator")
 
 
+def convert_swagger_bracket_to_flask(route):
+    """This will convert the swagger format of 'route/{id}' to the flask python
+    format of 'route/<int:id>'."""
+    output = re.sub(r"\{(.*)}", "<int:" + r"\1" + ">", route)
+    return output
+
+
 def get_enabled_routes_for_orm(resource_orm: object, swagger: dict) -> dict:
     """Given a resource orm (name) and a swagger spec, get all enabled
     routes."""
-    return {}
+    routes = [route for route in swagger["paths"]]
+
+    enabled_routes = {}
+
+    for route in routes:
+        verbs = [k for k, v in swagger["paths"][route].items()]
+        verbs.sort()
+        enabled_routes[convert_swagger_bracket_to_flask(route)] = verbs
+
+    return enabled_routes
 
 
 def generate_api(base=None, swagger: dict = None, api=None) -> None:

--- a/data_resource/generator/api_manager/api_generator.py
+++ b/data_resource/generator/api_manager/api_generator.py
@@ -56,6 +56,11 @@ def generate_rest_api_routes(
     )
 
     for idx, route in enumerate(resources):
-        api.add_resource(resource_api, route, endpoint=f"{resource_name}_ep_{idx}")
+        api.add_resource(
+            resource_api,
+            route,
+            endpoint=f"{resource_name}_ep_{idx}",
+            methods=enabled_routes[route],
+        )
 
     return resources

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -19,3 +19,11 @@ API Configuration
 ^^^^^^^^^^^^^^^^^
 
 A swagger file is used to configure the API. Only HTTP verbs present under routes will be enabled.
+
+Because of this it also means that the three main routes for each resource,
+
+- GET ALL
+- GET ID
+- POST QUERY
+
+If these paths are not included in the swagger spec then they will not be added to the API routing. This is an untested and unsupported feature that probably works.

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -1,8 +1,21 @@
 Configuration
 =============
 
+Application Configuration
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
 Configuration occurs with the ConfigFactory.
 
 Given an environmental variable for APP_ENV (default TEST) the application will select specific variables.
 
 These variables are mostly for connecting to the database in different environments. However, if your deployment is unique you can extend the config factory to include the variables you need.
+
+Database Configuration
+^^^^^^^^^^^^^^^^^^^^^^
+
+Data Resource Generator uses table schema as the basis for database configuration.
+
+API Configuration
+^^^^^^^^^^^^^^^^^
+
+A swagger file is used to configure the API. Only HTTP verbs present under routes will be enabled.

--- a/tests/api_manager/test_api_generation.py
+++ b/tests/api_manager/test_api_generation.py
@@ -1,6 +1,7 @@
 from data_resource.generator.api_manager.api_generator import (
     generate_rest_api_routes,
     get_enabled_routes_for_orm,
+    convert_swagger_bracket_to_flask,
 )
 from data_resource.generator.app import start_data_resource_generator, save_swagger
 import pytest
@@ -80,17 +81,24 @@ def test_get_enabled_routes_for_orm():
     test_orm = Table("test", metadata, Column("id", Integer, primary_key=True))
     fake_swagger = {
         "paths": {
-            "/test": {"get": {}, "post": {}, "put": {}, "patch": {}, "delete": {}},
-            "/test/{id}": {"get": {}, "post": {}, "put": {}, "patch": {}},
-            "/test/query": {"get": {}, "post": {}, "put": {}},
+            "/test": {"GET": {}, "POST": {}, "PUT": {}, "PATCH": {}, "DELETE": {}},
+            "/test/{id}": {"GET": {}, "POST": {}, "PUT": {}, "PATCH": {}},
+            "/test/query": {"GET": {}, "POST": {}, "PUT": {}},
         }
     }
     expected_result = {
-        "/test": ["GET", "PUT", "PATCH", "POST", "DELETE"],
-        "/test/<int:id>": ["GET", "PUT", "PATCH", "POST", "DELETE"],
-        "/test/query": ["GET", "PUT", "PATCH", "POST", "DELETE"],
+        "/test": ["DELETE", "GET", "PATCH", "POST", "PUT"],
+        "/test/<int:id>": ["GET", "PATCH", "POST", "PUT"],
+        "/test/query": ["GET", "POST", "PUT"],
     }
 
     result = get_enabled_routes_for_orm(test_orm, fake_swagger)
 
     assert result == expected_result
+
+
+@pytest.mark.unit
+def test_convert_swagger_bracket_to_flask():
+    result = convert_swagger_bracket_to_flask("/test/{id}")
+
+    assert result == "/test/<int:id>"

--- a/tests/api_manager/test_api_generation.py
+++ b/tests/api_manager/test_api_generation.py
@@ -14,35 +14,57 @@ from sqlalchemy import Column, Integer, Table, MetaData
 @pytest.mark.unit
 def test_generate_rest_api_routes(valid_base, empty_api):
     test_base = declarative_base()
+    enabled_routes = {
+        "/team": ["DELETE", "GET", "PATCH", "POST", "PUT"],
+        "/team/<int:id>": ["GET", "PATCH", "POST", "PUT"],
+        "/team/query": ["GET", "POST", "PUT"],
+    }
 
     class team(test_base):
         __tablename__ = "it reads class name not tablename"
         id = Column(Integer, primary_key=True)
 
-    generate_rest_api_routes(empty_api, team)
+    generate_rest_api_routes(empty_api, team, enabled_routes)
 
-    assert len(empty_api.endpoints) == 3
-    assert "team_ep_0" in empty_api.endpoints
-    assert "team_ep_1" in empty_api.endpoints
-    assert "team_ep_2" in empty_api.endpoints
+    def convert_methods_to_test_format(item: dict) -> list:
+        item.remove("OPTIONS")
+        item.remove("HEAD")
+        output = list(item)
+        output.sort()
+        return output
 
-    # Assert all http verbs are present
-    for rule in empty_api.app.url_map.iter_rules():
-        if "static" in repr(rule):
-            continue
+    result = {
+        str(r): convert_methods_to_test_format(r.methods)
+        for r in empty_api.app.url_map.iter_rules()
+    }
 
-        assert all(
-            [
-                http_verb in rule.methods
-                for http_verb in ["GET", "POST", "PATCH", "DELETE", "PUT"]
-            ]
-        )
+    del result["/static/<path:filename>"]
 
-        # Assert that all urls are correct
-        # import pdb; pdb.set_trace()
-        # url_for(rules)
-        #         (Pdb) url_for(rule)
-        # *** RuntimeError: Attempted to generate a URL without the application context being pushed. This has to be executed when application context is available.
+    assert result == enabled_routes
+
+    # assert len(empty_api.endpoints) == 3
+    # assert "team_ep_0" in empty_api.endpoints
+    # assert "team_ep_1" in empty_api.endpoints
+    # assert "team_ep_2" in empty_api.endpoints
+
+    # # Assert all http verbs are present
+
+    # for rule in empty_api.app.url_map.iter_rules():
+    #     if "static" in repr(rule):
+    #         continue
+
+    #     assert all(
+    #         [
+    #             http_verb in rule.methods
+    #             for http_verb in ["GET", "POST", "PATCH", "DELETE", "PUT"]
+    #         ]
+    #     )
+
+    # Assert that all urls are correct
+    # import pdb; pdb.set_trace()
+    # url_for(rules)
+    #         (Pdb) url_for(rule)
+    # *** RuntimeError: Attempted to generate a URL without the application context being pushed. This has to be executed when application context is available.
 
 
 @pytest.mark.unit

--- a/tests/api_manager/test_api_generation.py
+++ b/tests/api_manager/test_api_generation.py
@@ -11,6 +11,7 @@ from sqlalchemy import Column, Integer, Table, MetaData
 
 # Given a tableschema assert the correct flask restful routes are generated
 # use declarative base/table for ease instead of DeclarativeMeta
+# TODO test the e2e case where the top level routes are not present in swagger.
 @pytest.mark.unit
 def test_generate_rest_api_routes(valid_base, empty_api):
     test_base = declarative_base()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -298,7 +298,7 @@ api_dict = {
         }
     ],
     "paths": {
-        "/peoples": {
+        "/people": {
             "get": {
                 "operationId": "get_people",
                 "tags": ["peoples"],
@@ -317,7 +317,7 @@ api_dict = {
                 "responses": {"201": {"$ref": "#/components/responses/Created"}},
             },
         },
-        "/peoples/{id}": {
+        "/people/{id}": {
             "get": {
                 "operationId": "get_people_id",
                 "tags": ["peoples"],
@@ -389,6 +389,7 @@ api_dict = {
                 "responses": {"200": {"description": "ok"}},
             },
         },
+        "/people/query": {"get": {}, "post": {}},
     },
 }
 


### PR DESCRIPTION
# Pull Request

## Description

https://app.clubhouse.io/brighthive/story/1162/drg-only-creates-http-verb-found-in-swagger

Only adds routes and HTTP verbs if they are present in Swagger.

## Checklists

### Basic

- [x] Did you write tests for the code in this PR?
- [x] Did you document your changes in the README and/or in docstrings (as needed)?

### Security

- [ ] Authorization has been implemented across these changes
- [ ] Injection has been prevented (parameterized queries, no eval or system calls)
- [ ] Any web UI is escaping output (to prevent XSS)
- [ ] Sensitive data has been identified and is being protected properly

## Notes for the Reviewer

None.
