### PR TITLE
Drg can restart safely/feature/ch1248/loganripplinger

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -11,7 +11,7 @@ pytest-mock = "*"
 sphinx = "*"
 
 [packages]
-tableschema-sql = "*"
+tableschema-sql = "==1.3.1"
 psycopg2-binary = "*"
 sqlalchemy = "*"
 flask-sqlalchemy = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "5dbd5d29c9de98dbb2eddeda76a20b42fd5aeb8ec32e5dfcdc21f2ffabe9cad4"
+            "sha256": "4888c31bd87bf762a187fbc5741ae22d044ce809ddf25ee1731ee8196b062418"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -28,28 +28,27 @@
                 "sha256:08a96c641c3a74e44eb59afb61a24f2cb9f4d7188748e76ba4bb5edfa3cb7d1c",
                 "sha256:f7b7ce16570fe9965acd6d30101a28f62fb4a7f9e926b3bbc9b61f8b04247e72"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==19.3.0"
         },
         "bitarray": {
             "hashes": [
-                "sha256:27a69ffcee3b868abab3ce8b17c69e02b63e722d4d64ffd91d659f81e9984954"
+                "sha256:a48dd9db14922052d226731cb9f43e1c54ae428372b5e33c586c7c9853f3e3df"
             ],
-            "version": "==1.2.2"
+            "version": "==1.3.0"
         },
         "boto3": {
             "hashes": [
-                "sha256:77d926c16ab2ab2bfe68811f3bc987e7d79c97f3e2adebf9265c587cdb1fc47b",
-                "sha256:7f558165eaa608a5d0e05227ee820f4b3cc74533a52c9dde7eb488eba091d50d"
+                "sha256:00369459682e1d0f21d1143437b1f6d212f5f31b3f58fe69fc9c909c1218b05a",
+                "sha256:72cb54d2d4b9ac0edd5c256d25c28ec26bc4779fd7f540fc1ebef33376855842"
             ],
-            "version": "==1.14.13"
+            "version": "==1.14.18"
         },
         "botocore": {
             "hashes": [
-                "sha256:37b65cc48c99b7dd4d5606e56f76ecd88eb7be392ea8a166df734a6b3035301c",
-                "sha256:5ac9b53a75852fe4282be8741c8136e6948714fef6eff1bd9babb861f8647ba3"
+                "sha256:11c9da2afc3a7abb09fff3ab73b8f0dac5a9e5396102f88768ad2ad4b3854e61",
+                "sha256:30a9d64eedbf02471b56673394f100cb6d3237d6725e5a35ca24988adf166125"
             ],
-            "version": "==1.17.13"
+            "version": "==1.17.18"
         },
         "brighthive-authlib": {
             "hashes": [
@@ -84,7 +83,6 @@
                 "sha256:d2b5255c7c6349bc1bd1e59e08cd12acbbd63ce649f2588755783aa94dfb6b1a",
                 "sha256:dacca89f4bfadd5de3d7489b7c8a566eee0d3676333fbb50030263894c38c0dc"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==7.1.2"
         },
         "clickclick": {
@@ -116,7 +114,6 @@
                 "sha256:9e4d7ecfc600058e07ba661411a2b7de2fd0fafa17d1a7f7361cd47b1175c827",
                 "sha256:a2aeea129088da402665e92e0b25b04b073c04b2dce4ab65caaa38b7ce2e1a99"
             ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==0.15.2"
         },
         "ecdsa": {
@@ -124,7 +121,6 @@
                 "sha256:867ec9cf6df0b03addc8ef66b56359643cb5d0c1dc329df76ba7ecfe256c8061",
                 "sha256:8f12ac317f8a1318efa75757ef0a651abe12e51fc1af8838fb91079445227277"
             ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==0.15"
         },
         "et-xmlfile": {
@@ -138,7 +134,6 @@
                 "sha256:4efa1ae2d7c9865af48986de8aeb8504bf32c7f3d6fdc9353d34b21f4b127060",
                 "sha256:8a4fdd8936eba2512e9c85df320a37e694c93945b33ef33c89946a340a238557"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==1.1.2"
         },
         "flask-restful": {
@@ -234,7 +229,6 @@
                 "sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6",
                 "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.10"
         },
         "ijson": {
@@ -275,7 +269,6 @@
                 "sha256:88b101b2668a1d81d6d72d4c2018e53bc6c7fc544c987849da1c7f77545c3bc9",
                 "sha256:f576e85132d34f5bf7df5183c2c6f94cfb32e528f53065345cf71329ba0b8924"
             ],
-            "markers": "python_version >= '3.5'",
             "version": "==0.5.0"
         },
         "isodate": {
@@ -290,7 +283,6 @@
                 "sha256:321b033d07f2a4136d3ec762eac9f16a10ccd60f53c0c91af90217ace7ba1f19",
                 "sha256:b12271b2047cb23eeb98c8b5622e2e5c5e9abd9784a153e9d8ef9cb4dd09d749"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.1.0"
         },
         "jdcal": {
@@ -305,7 +297,6 @@
                 "sha256:89aab215427ef59c34ad58735269eb58b1a5808103067f7bb9d5836c651b3bb0",
                 "sha256:f0a4641d3cf955324a89c04f3d94663aa4d638abe8f733ecd3582848e1c37035"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==2.11.2"
         },
         "jmespath": {
@@ -313,7 +304,6 @@
                 "sha256:b85d0567b8666149a93172712e68920734333c0ce7e89b78b3e987f71e5ed4f9",
                 "sha256:cdf6525904cc597730141d61b36f2e4b8ecc257c420fa2f4549bac2c2d0cb72f"
             ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==0.10.0"
         },
         "jsonlines": {
@@ -372,7 +362,6 @@
                 "sha256:e249096428b3ae81b08327a63a485ad0878de3fb939049038579ac0ef61e17e7",
                 "sha256:e8313f01ba26fbbe36c7be1966a7b7424942f670f38e666995b88d012765b9be"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.1.1"
         },
         "openapi-spec-validator": {
@@ -385,9 +374,9 @@
         },
         "openpyxl": {
             "hashes": [
-                "sha256:6e62f058d19b09b95d20ebfbfb04857ad08d0833190516c1660675f699c6186f"
+                "sha256:6e62f058d19b09b95d20ebfbfb04857ad08d0833190516c1660675f699c6186f",
+                "sha256:d88dd1480668019684c66cfff3e52a5de4ed41e9df5dd52e008cbf27af0dbf87"
             ],
-            "markers": "python_version >= '3.6'",
             "version": "==3.0.4"
         },
         "psycopg2-binary": {
@@ -428,19 +417,8 @@
         },
         "pyasn1": {
             "hashes": [
-                "sha256:014c0e9976956a08139dc0712ae195324a75e142284d5f87f1a87ee1b068a359",
-                "sha256:03840c999ba71680a131cfaee6fab142e1ed9bbd9c693e285cc6aca0d555e576",
-                "sha256:0458773cfe65b153891ac249bcf1b5f8f320b7c2ce462151f8fa74de8934becf",
-                "sha256:08c3c53b75eaa48d71cf8c710312316392ed40899cb34710d092e96745a358b7",
                 "sha256:39c7e2ec30515947ff4e87fb6f456dfc6e84857d34be479c9d4a4ba4bf46aa5d",
-                "sha256:5c9414dcfede6e441f7e8f81b43b34e834731003427e5b09e4e00e3172a10f00",
-                "sha256:6e7545f1a61025a4e58bb336952c5061697da694db1cae97b116e9c46abcf7c8",
-                "sha256:78fa6da68ed2727915c4767bb386ab32cdba863caa7dbe473eaae45f9959da86",
-                "sha256:7ab8a544af125fb704feadb008c99a88805126fb525280b2270bb25cc1d78a12",
-                "sha256:99fcc3c8d804d1bc6d9a099921e39d827026409a58f2a720dcdb89374ea0c776",
-                "sha256:aef77c9fb94a3ac588e87841208bdec464471d9871bd5050a287cc9a475cd0ba",
-                "sha256:e89bf84b5437b532b0803ba5c9a5e054d21fec423a89952a74f87fa2c9b7bce2",
-                "sha256:fec3e9d8e36808a28efb59b489e4528c10ad0f480e57dcc32b4de5c9d8c9fdf3"
+                "sha256:aef77c9fb94a3ac588e87841208bdec464471d9871bd5050a287cc9a475cd0ba"
             ],
             "version": "==0.4.8"
         },
@@ -496,7 +474,6 @@
                 "sha256:73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c",
                 "sha256:75bb3f31ea686f1197762692a9ee6a7550b59fc6ca3a1f4b5d7e32fb98e2da2a"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.8.1"
         },
         "python-jose": {
@@ -537,7 +514,6 @@
                 "sha256:b3559a131db72c33ee969480840fff4bb6dd111de7dd27c8ee1f820f4f00231b",
                 "sha256:fe75cc94a9443b9246fc7049224f75604b113c36acb93f87b80ed42c44cbb898"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==2.24.0"
         },
         "rfc3986": {
@@ -550,7 +526,6 @@
         "rsa": {
             "hashes": [
                 "sha256:109ea5a66744dd859bf16fe904b8d8b627adafb9408753161e766a92e7d681fa",
-                "sha256:23778f5523461cf86ae075f9482a99317f362bca752ae57cb118044066f4026f",
                 "sha256:6166864e23d6b5195a5cfed6cd9fed0fe774e226d8f854fcb23b7bbef0350233"
             ],
             "index": "pypi",
@@ -568,7 +543,6 @@
                 "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259",
                 "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.15.0"
         },
         "sqlalchemy": {
@@ -655,7 +629,6 @@
                 "sha256:2de2a5db0baeae7b2d2664949077c2ac63fbd16d98da0ff71837f7d1dea3fd43",
                 "sha256:6c80b1e5ad3665290ea39320b91e1be1e0d5f60652b964a3070216de83d2e47c"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==1.0.1"
         },
         "xlrd": {
@@ -663,7 +636,6 @@
                 "sha256:546eb36cee8db40c3eaa46c351e67ffee6eeb5fa2650b71bc4c758a29a1b29b2",
                 "sha256:e551fb498759fa3a5384a94ccd4c3c02eb7c00ea424426e212ac0c57be9dfbde"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.2.0"
         },
         "zipp": {
@@ -671,7 +643,6 @@
                 "sha256:aa36550ff0c0b7ef7fa639055d797116ee891440eac1a56f378e2d3179e0320b",
                 "sha256:c599e4d75c98f6798c509911d08a22e6c021d074469042177c8c86fb92eefd96"
             ],
-            "markers": "python_version >= '3.6'",
             "version": "==3.1.0"
         },
         "zope.event": {
@@ -724,7 +695,6 @@
                 "sha256:f68bf937f113b88c866d090fea0bc52a098695173fc613b055a17ff0cf9683b6",
                 "sha256:fb55c182a3f7b84c1a2d6de5fa7b1a05d4660d866b91dbf8d74549c57a1499e8"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==5.1.0"
         }
     },
@@ -748,7 +718,6 @@
                 "sha256:08a96c641c3a74e44eb59afb61a24f2cb9f4d7188748e76ba4bb5edfa3cb7d1c",
                 "sha256:f7b7ce16570fe9965acd6d30101a28f62fb4a7f9e926b3bbc9b61f8b04247e72"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==19.3.0"
         },
         "babel": {
@@ -756,7 +725,6 @@
                 "sha256:1aac2ae2d0d8ea368fa90906567f5c08463d98ade155c0c4bfedd6a0f7160e38",
                 "sha256:d670ea0b10f8b723672d3a6abeb87b565b244da220d76b4dba1b66269ec152d4"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.8.0"
         },
         "certifi": {
@@ -771,7 +739,6 @@
                 "sha256:1ccf53320421aeeb915275a196e23b3b8ae87dea8ac6698b1638001d4a486d53",
                 "sha256:c8e8f552ffcc6194f4e18dd4f68d9aef0c0d58ae7e7be8c82bee3c5e9edfa513"
             ],
-            "markers": "python_full_version >= '3.6.1'",
             "version": "==3.1.0"
         },
         "chardet": {
@@ -794,7 +761,6 @@
                 "sha256:9e4d7ecfc600058e07ba661411a2b7de2fd0fafa17d1a7f7361cd47b1175c827",
                 "sha256:a2aeea129088da402665e92e0b25b04b073c04b2dce4ab65caaa38b7ce2e1a99"
             ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==0.15.2"
         },
         "expects": {
@@ -813,18 +779,16 @@
         },
         "identify": {
             "hashes": [
-                "sha256:acf0712ab4042642e8f44e9532d95c26fbe60c0ab8b6e5b654dd1bc6512810e0",
-                "sha256:b2cd24dece806707e0b50517c1b3bcf3044e0b1cb13a72e7d34aa31c91f2a55a"
+                "sha256:c4d07f2b979e3931894170a9e0d4b8281e6905ea6d018c326f7ffefaf20db680",
+                "sha256:dac33eff90d57164e289fb20bf4e131baef080947ee9bf45efcd0da8d19064bf"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==1.4.20"
+            "version": "==1.4.21"
         },
         "idna": {
             "hashes": [
                 "sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6",
                 "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.10"
         },
         "imagesize": {
@@ -832,7 +796,6 @@
                 "sha256:6965f19a6a2039c7d48bca7dba2473069ff854c36ae6f19d2cde309d998228a1",
                 "sha256:b1f6b5a4eab1f73479a50fb79fcf729514a900c341d8503d62a62dbc4127a2b1"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.2.0"
         },
         "importlib-metadata": {
@@ -848,7 +811,6 @@
                 "sha256:89aab215427ef59c34ad58735269eb58b1a5808103067f7bb9d5836c651b3bb0",
                 "sha256:f0a4641d3cf955324a89c04f3d94663aa4d638abe8f733ecd3582848e1c37035"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==2.11.2"
         },
         "markupsafe": {
@@ -887,7 +849,6 @@
                 "sha256:e249096428b3ae81b08327a63a485ad0878de3fb939049038579ac0ef61e17e7",
                 "sha256:e8313f01ba26fbbe36c7be1966a7b7424942f670f38e666995b88d012765b9be"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.1.1"
         },
         "more-itertools": {
@@ -895,7 +856,6 @@
                 "sha256:68c70cc7167bdf5c7c9d8f6954a7837089c6a36bf565383919bb595efb8a17e5",
                 "sha256:b78134b2063dd214000685165d81c154522c3ee0a1c0d4d113c80361c234c5a2"
             ],
-            "markers": "python_version >= '3.5'",
             "version": "==8.4.0"
         },
         "nodeenv": {
@@ -909,7 +869,6 @@
                 "sha256:4357f74f47b9c12db93624a82154e9b120fa8293699949152b22065d556079f8",
                 "sha256:998416ba6962ae7fbd6596850b80e17859a5753ba17c32284f67bfff33784181"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==20.4"
         },
         "pluggy": {
@@ -917,23 +876,21 @@
                 "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0",
                 "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==0.13.1"
         },
         "pre-commit": {
             "hashes": [
-                "sha256:c5c8fd4d0e1c363723aaf0a8f9cba0f434c160b48c4028f4bae6d219177945b3",
-                "sha256:da463cf8f0e257f9af49047ba514f6b90dbd9b4f92f4c8847a3ccd36834874c7"
+                "sha256:1657663fdd63a321a4a739915d7d03baedd555b25054449090f97bb0cb30a915",
+                "sha256:e8b1315c585052e729ab7e99dcca5698266bedce9067d21dc909c23e3ceed626"
             ],
             "index": "pypi",
-            "version": "==2.5.1"
+            "version": "==2.6.0"
         },
         "py": {
             "hashes": [
                 "sha256:366389d1db726cd2fcfc79732e75410e5fe4d31db13692115529d34069a043c2",
                 "sha256:9ca6883ce56b4e8da7e79ac18787889fa5206c79dcc67fb065376cd2fe03f342"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.9.0"
         },
         "pygments": {
@@ -941,7 +898,6 @@
                 "sha256:647344a061c249a3b74e230c739f434d7ea4d8b1d5f3721bc0f3558049b38f44",
                 "sha256:ff7a40b4860b727ab48fad6360eb351cc1b33cbf9b15a0f689ca5353e9463324"
             ],
-            "markers": "python_version >= '3.5'",
             "version": "==2.6.1"
         },
         "pyparsing": {
@@ -949,7 +905,6 @@
                 "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1",
                 "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"
             ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.4.7"
         },
         "pytest": {
@@ -996,7 +951,6 @@
                 "sha256:b3559a131db72c33ee969480840fff4bb6dd111de7dd27c8ee1f820f4f00231b",
                 "sha256:fe75cc94a9443b9246fc7049224f75604b113c36acb93f87b80ed42c44cbb898"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==2.24.0"
         },
         "six": {
@@ -1004,7 +958,6 @@
                 "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259",
                 "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.15.0"
         },
         "snowballstemmer": {
@@ -1016,18 +969,17 @@
         },
         "sphinx": {
             "hashes": [
-                "sha256:74fbead182a611ce1444f50218a1c5fc70b6cc547f64948f5182fb30a2a20258",
-                "sha256:97c9e3bcce2f61d9f5edf131299ee9d1219630598d9f9a8791459a4d9e815be5"
+                "sha256:97dbf2e31fc5684bb805104b8ad34434ed70e6c588f6896991b2fdfd2bef8c00",
+                "sha256:b9daeb9b39aa1ffefc2809b43604109825300300b987a24f45976c001ba1a8fd"
             ],
             "index": "pypi",
-            "version": "==3.1.1"
+            "version": "==3.1.2"
         },
         "sphinxcontrib-applehelp": {
             "hashes": [
                 "sha256:806111e5e962be97c29ec4c1e7fe277bfd19e9652fb1a4392105b43e01af885a",
                 "sha256:a072735ec80e7675e3f432fcae8610ecf509c5f1869d17e2eecff44389cdbc58"
             ],
-            "markers": "python_version >= '3.5'",
             "version": "==1.0.2"
         },
         "sphinxcontrib-devhelp": {
@@ -1035,7 +987,6 @@
                 "sha256:8165223f9a335cc1af7ffe1ed31d2871f325254c0423bc0c4c7cd1c1e4734a2e",
                 "sha256:ff7f1afa7b9642e7060379360a67e9c41e8f3121f2ce9164266f61b9f4b338e4"
             ],
-            "markers": "python_version >= '3.5'",
             "version": "==1.0.2"
         },
         "sphinxcontrib-htmlhelp": {
@@ -1043,7 +994,6 @@
                 "sha256:3c0bc24a2c41e340ac37c85ced6dafc879ab485c095b1d65d2461ac2f7cca86f",
                 "sha256:e8f5bb7e31b2dbb25b9cc435c8ab7a79787ebf7f906155729338f3156d93659b"
             ],
-            "markers": "python_version >= '3.5'",
             "version": "==1.0.3"
         },
         "sphinxcontrib-jsmath": {
@@ -1051,7 +1001,6 @@
                 "sha256:2ec2eaebfb78f3f2078e73666b1415417a116cc848b72e5172e596c871103178",
                 "sha256:a9925e4a4587247ed2191a22df5f6970656cb8ca2bd6284309578f2153e0c4b8"
             ],
-            "markers": "python_version >= '3.5'",
             "version": "==1.0.1"
         },
         "sphinxcontrib-qthelp": {
@@ -1059,7 +1008,6 @@
                 "sha256:4c33767ee058b70dba89a6fc5c1892c0d57a54be67ddd3e7875a18d14cba5a72",
                 "sha256:bd9fc24bcb748a8d51fd4ecaade681350aa63009a347a8c14e637895444dfab6"
             ],
-            "markers": "python_version >= '3.5'",
             "version": "==1.0.3"
         },
         "sphinxcontrib-serializinghtml": {
@@ -1067,7 +1015,6 @@
                 "sha256:eaa0eccc86e982a9b939b2b82d12cc5d013385ba5eadcc7e4fed23f4405f77bc",
                 "sha256:f242a81d423f59617a8e5cf16f5d4d74e28ee9a66f9e5b637a18082991db5a9a"
             ],
-            "markers": "python_version >= '3.5'",
             "version": "==1.1.4"
         },
         "toml": {
@@ -1087,11 +1034,10 @@
         },
         "virtualenv": {
             "hashes": [
-                "sha256:f332ba0b2dfbac9f6b1da9f11224f0036b05cdb4df23b228527c2a2d5504aeed",
-                "sha256:ffffcb3c78a671bb3d590ac3bc67c081ea2188befeeb058870cba13e7f82911b"
+                "sha256:c11a475400e98450403c0364eb3a2d25d42f71cf1493da64390487b666de4324",
+                "sha256:e10cc66f40cbda459720dfe1d334c4dc15add0d80f09108224f171006a97a172"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==20.0.25"
+            "version": "==20.0.26"
         },
         "wcwidth": {
             "hashes": [
@@ -1105,7 +1051,6 @@
                 "sha256:aa36550ff0c0b7ef7fa639055d797116ee891440eac1a56f378e2d3179e0320b",
                 "sha256:c599e4d75c98f6798c509911d08a22e6c021d074469042177c8c86fb92eefd96"
             ],
-            "markers": "python_version >= '3.6'",
             "version": "==3.1.0"
         }
     }

--- a/README.md
+++ b/README.md
@@ -81,6 +81,18 @@ then run:
 docker-compose up
 ```
 
+To use AWS Secret Manager set environment variable `AWS_SM_ENABLED` to `1` (default 0). This will enabled the feature but will require the following environment variables to initialize correctly:
+
+```bash
+export AWS_SM_ENABLED=1
+export AWS_SM_NAME=<aws-secet-name> ex. my-data-secrets
+export AWS_SM_REGION=<aws-region> ex. us-west-1
+export AWS_SM_DBNAME=<rds-database-name> ex. postgres
+export AWS_ACCESS_KEY_ID=<aws-key-id>
+export AWS_SECRET_ACCESS_KEY=<aws-secret>
+```
+For more information about AWS SM and how to setup on AWS console please visit: <a href="https://aws.amazon.com/secrets-manager/">AWS SM Docs</a>
+
 #### Using python
 
 1. Restart the database to clear the data.
@@ -184,6 +196,7 @@ For developers to run the test suite,
 
 - Logan Ripplinger (Software Engineer)
 - Gregory Mundy (VP of Engineering)
+- John O'Sullivan (Software Engineer)
 
 ## License
 

--- a/data_resource/admin/app.py
+++ b/data_resource/admin/app.py
@@ -1,3 +1,5 @@
+import os
+import json
 from data_resource.admin.routes import (
     tableschema_bp,
     tableschema_id_bp,
@@ -5,14 +7,14 @@ from data_resource.admin.routes import (
     generator_bp,
 )
 from data_resource.db import db_session, admin_base, engine
-from flask import Flask, make_response
-from flask_restful import Api
 from data_resource.logging.api_exceptions import handle_errors
-from flask_swagger_ui import get_swaggerui_blueprint
 from data_resource.logging import LogFactory
-import os
 from data_resource.config import ConfigurationFactory
 from data_resource.admin.safe_json_output import safe_json_dumps
+from data_resource.generator.app import start_data_resource_generator
+from flask_swagger_ui import get_swaggerui_blueprint
+from flask import Flask, make_response
+from flask_restful import Api
 
 
 logger = LogFactory.get_console_logger("admin:app")
@@ -69,7 +71,27 @@ def create_app(actually_run=True):
         db_session.rollback()
         db_session.remove()
 
+    # # Check if we need to turn on API/model already
+    # @app.before_first_request
+    handle_existing_data_resource_schema(api)
+
     if actually_run:
         app.run(host="0.0.0.0", port=8081, use_reloader=False, threaded=False)  # nosec
+
     else:
         return app
+
+
+def handle_existing_data_resource_schema(api: Api):
+    if not os.path.exists("./static/data_resource_schema.json"):
+        return
+
+    logger.info("Found an existing data resource schema. Attempting to load it...")
+
+    # TODO check for invalid doc
+    with open("./static/data_resource_schema.json") as json_file:
+        data_resource_schema = json.load(json_file)
+
+    start_data_resource_generator(data_resource_schema, api)
+
+    logger.info("Loaded existing data resource schema.")

--- a/data_resource/admin/app.py
+++ b/data_resource/admin/app.py
@@ -21,13 +21,11 @@ logger = LogFactory.get_console_logger("admin:app")
 
 
 def create_app(actually_run=True):
-    # TODO: this or env var
-    dirname, _ = os.path.split(os.path.abspath(__file__))
-    static_folder = os.path.abspath(
-        os.path.join(dirname, "../../")
-    )  # This should be the static folder at the root of the project folder
-
-    app = Flask(__name__, static_url_path="", static_folder=static_folder)
+    app = Flask(
+        __name__,
+        static_url_path="",
+        static_folder=ConfigurationFactory.from_env().STATIC_FOLDER,
+    )
     app.config.from_object(ConfigurationFactory.from_env())
     app.config["engine"] = engine
 
@@ -59,7 +57,6 @@ def create_app(actually_run=True):
 
     # Save API to grab later at generation time
     app.config["api"] = api
-    app.config["static_folder"] = static_folder  # TODO: this or env var
 
     # Create the models
     import data_resource.admin.models  # noqa: F401
@@ -92,6 +89,6 @@ def handle_existing_data_resource_schema(api: Api):
     with open("./static/data_resource_schema.json") as json_file:
         data_resource_schema = json.load(json_file)
 
-    start_data_resource_generator(data_resource_schema, api)
+    start_data_resource_generator(data_resource_schema, api, touch_database=False)
 
     logger.info("Loaded existing data resource schema.")

--- a/data_resource/admin/app.py
+++ b/data_resource/admin/app.py
@@ -68,8 +68,7 @@ def create_app(actually_run=True):
         db_session.rollback()
         db_session.remove()
 
-    # # Check if we need to turn on API/model already
-    # @app.before_first_request
+    # Check if we need to turn on API/model already
     handle_existing_data_resource_schema(api)
 
     if actually_run:

--- a/data_resource/config/configuration.py
+++ b/data_resource/config/configuration.py
@@ -22,6 +22,9 @@ class Config:
     data resources.
     """
 
+    dirname, _ = os.path.split(os.path.abspath(__file__))
+    STATIC_FOLDER = os.path.abspath(os.path.join(dirname, "../../"))
+
     RELATIVE_PATH = os.path.dirname(os.path.relpath(__file__))
     ABSOLUTE_PATH = os.path.dirname(os.path.abspath(__file__))
     ROOT_PATH = ABSOLUTE_PATH.split(RELATIVE_PATH)[0]
@@ -148,25 +151,25 @@ class TestConfig(Config):
 
 
 class ProductionConfig(Config):
-     """Production deployment configuration class."""
+    """Production deployment configuration class."""
 
-     def __init__(self):
-         super().__init__()
+    def __init__(self):
+        super().__init__()
 
-     SQLALCHEMY_TRACK_MODIFICATIONS = False
-     PROPAGATE_EXCEPTIONS = True
-     POSTGRES_USER = os.getenv("POSTGRES_USER")
-     POSTGRES_PASSWORD = os.getenv("POSTGRES_PASSWORD")
-     POSTGRES_DATABASE = os.getenv("POSTGRES_DATABASE")
-     POSTGRES_HOSTNAME = os.getenv("POSTGRES_HOSTNAME", "localhost")
-     POSTGRES_PORT = os.getenv("POSTGRES_PORT", 5432)
-     SQLALCHEMY_DATABASE_URI = "postgresql+psycopg2://{}:{}@{}:{}/{}".format(
+    SQLALCHEMY_TRACK_MODIFICATIONS = False
+    PROPAGATE_EXCEPTIONS = True
+    POSTGRES_USER = os.getenv("POSTGRES_USER")
+    POSTGRES_PASSWORD = os.getenv("POSTGRES_PASSWORD")
+    POSTGRES_DATABASE = os.getenv("POSTGRES_DATABASE")
+    POSTGRES_HOSTNAME = os.getenv("POSTGRES_HOSTNAME", "localhost")
+    POSTGRES_PORT = os.getenv("POSTGRES_PORT", 5432)
+    SQLALCHEMY_DATABASE_URI = "postgresql+psycopg2://{}:{}@{}:{}/{}".format(
         POSTGRES_USER,
         POSTGRES_PASSWORD,
         POSTGRES_HOSTNAME,
         POSTGRES_PORT,
         POSTGRES_DATABASE,
-     )
+    )
 
 
 class ConfigurationFactory:
@@ -192,7 +195,7 @@ class ConfigurationFactory:
         if config_type == "TEST":
             return TestConfig()
         elif config_type == "PRODUCTION":
-             return ProductionConfig()
+            return ProductionConfig()
         else:
             raise InvalidConfigurationError(
                 "Invalid configuration type `{}` specified.".format(config_type)

--- a/data_resource/generator/app.py
+++ b/data_resource/generator/app.py
@@ -23,14 +23,19 @@ def save_swagger(swagger):
         _file.write(json.dumps(swagger))
 
 
-def start_data_resource_generator(data_catalog, api):
-    data_dict = data_catalog["data"]
+def start_data_resource_generator(data_resource_schema, api):
+    # save the data resource schema
+    # TODO if testing env then dont do this?
+    with open("./static/data_resource_schema.json", "w") as outfile:
+        json.dump(data_resource_schema, outfile)
+
+    data_dict = data_resource_schema["data"]
     try:
-        relationships = data_catalog["data"]["relationships"]["manyToMany"]
+        relationships = data_resource_schema["data"]["relationships"]["manyToMany"]
     except KeyError:
         relationships = []
 
-    swagger = data_catalog["api"]["apiSpec"]
+    swagger = data_resource_schema["api"]["apiSpec"]
 
     # Generate ORM
     base = create_models(data_dict)

--- a/data_resource/generator/app.py
+++ b/data_resource/generator/app.py
@@ -1,16 +1,15 @@
+from data_resource.config import ConfigurationFactory
 from data_resource.generator.api_manager import generate_api
 from data_resource.generator.model_manager import create_models
 from data_resource.logging import LogFactory
 import json
-from flask import current_app
 import os
-
 
 logger = LogFactory.get_console_logger("generator:app")
 
 
 def get_static_folder_from_app():
-    static_folder = current_app.config["static_folder"]
+    static_folder = ConfigurationFactory.from_env().STATIC_FOLDER
     return static_folder
 
 
@@ -23,7 +22,9 @@ def save_swagger(swagger):
         _file.write(json.dumps(swagger))
 
 
-def start_data_resource_generator(data_resource_schema, api):
+def start_data_resource_generator(
+    data_resource_schema, api, touch_database: bool = True
+):
     # save the data resource schema
     # TODO if testing env then dont do this?
     with open("./static/data_resource_schema.json", "w") as outfile:
@@ -38,7 +39,7 @@ def start_data_resource_generator(data_resource_schema, api):
     swagger = data_resource_schema["api"]["apiSpec"]
 
     # Generate ORM
-    base = create_models(data_dict)
+    base = create_models(data_dict, touch_database=touch_database)
 
     # Generate APIs
     generate_api(base=base, swagger=swagger, api=api, relationships=relationships)

--- a/data_resource/generator/model_manager/model_manager.py
+++ b/data_resource/generator/model_manager/model_manager.py
@@ -4,6 +4,7 @@ from sqlalchemy import Table, Integer, ForeignKey, Column
 from data_resource.db import engine
 from sqlalchemy.ext.automap import automap_base
 from data_resource.logging import LogFactory
+from sqlalchemy import MetaData
 
 
 logger = LogFactory.get_console_logger("generator:model-manager")
@@ -44,7 +45,10 @@ def create_all_tables_from_schemas(table_schemas: list) -> "Metadata":
     try:
         storage = Storage(engine=engine)
 
-        metadata = storage._Storage__metadata
+        # Override the reflection and capture reference to orm
+        metadata = storage._Storage__metadata = MetaData(
+            bind=engine
+        )  # , schema="generated"
 
         # Override create all so tableschema-sql won't handle table creation
         original_create_all = metadata.create_all

--- a/data_resource/generator/model_manager/model_manager.py
+++ b/data_resource/generator/model_manager/model_manager.py
@@ -10,7 +10,7 @@ logger = LogFactory.get_console_logger("generator:model-manager")
 
 
 # main
-def create_models(data_catalog: list) -> None:
+def create_models(data_catalog: list, touch_database: bool = True) -> None:
     """Given the data portion of a data catalog, Produce all the SQLAlchemy
     ORM."""
     # Create base items
@@ -24,7 +24,11 @@ def create_models(data_catalog: list) -> None:
     for relationship in relationships["manyToMany"]:
         _ = construct_many_to_many_assoc(metadata, relationship)
 
-    metadata.create_all()
+    if touch_database:
+        try:
+            metadata.create_all()
+        except:
+            logger.exception("Failed to create all models in database.")
 
     # Create ORM relationships
     base = automap_metadata(metadata)
@@ -68,9 +72,10 @@ def automap_metadata(metadata) -> "Base":
     base.prepare()
 
     # For testing
-    if base.metadata.is_bound() is True:
-        base.metadata.drop_all()
-        base.metadata.create_all()
+    # This probably needs to be removed -- idk why its here
+    # if base.metadata.is_bound() is True:
+    #     base.metadata.drop_all()
+    #     base.metadata.create_all()
 
     return base
 

--- a/data_resource/generator/model_manager/model_manager.py
+++ b/data_resource/generator/model_manager/model_manager.py
@@ -75,12 +75,6 @@ def automap_metadata(metadata) -> "Base":
     # calling prepare() just sets up mapped classes and relationships.
     base.prepare()
 
-    # For testing
-    # This probably needs to be removed -- idk why its here
-    # if base.metadata.is_bound() is True:
-    #     base.metadata.drop_all()
-    #     base.metadata.create_all()
-
     return base
 
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -5,6 +5,7 @@ Welcome to Data Resource Generator's documentation!
    :maxdepth: 2
    :caption: Contents:
 
+   running
    routes
    configuration
    datatypes

--- a/docs/source/running.rst
+++ b/docs/source/running.rst
@@ -1,0 +1,32 @@
+Running
+=======
+
+There are two ways to run the application. With an empty database or an already existing database.
+
+Empty database
+--------------
+
+In the case you want to generate a database, you will run the application with an empty database.
+
+Making a call to the generate route will trigger the building of ORM, API, and modify the database.
+
+Non-empty database
+------------------
+
+This application was not designed to be run on top of a database that already has tables in it (in other words, you can only run the generation process once).
+
+Restarting the application
+--------------------------
+
+Restarting of the application is supported. In the event that your application has applied migrations to the database you simply need to ensure you have a saved data_resource_schema.json file in the static folder.
+
+On startup the application will attempt to load the ORM and API based on the data resource schema file. In this mode, the application will not apply any modifiations to the database. You must ensure that the state of your database matches the state the data resource schema expects.
+
+In otherwords, you cannot modify the data resource schema after running the generation and expect the application to handle the migrations.
+
+Making changes to your database
+-------------------------------
+
+In the event you require modifications to your database and API, this is supported by ensuring the state of your database matches the state that the data resource schema expects.
+
+You must manually run migrations to your database and manually update your data resource schema. Then upon running the application, it will build the ORM and API determinisitcally and use the database expecting it to be in the correct state.

--- a/tests/api_manager/test_resource_api_generation.py
+++ b/tests/api_manager/test_resource_api_generation.py
@@ -6,7 +6,7 @@ from data_resource.generator.api_manager.api_generator import (
 from data_resource.generator.app import start_data_resource_generator, save_swagger
 import pytest
 from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy import Column, Integer, Table, MetaData
+from sqlalchemy import Column, Integer
 
 
 # Given a tableschema assert the correct flask restful routes are generated

--- a/tests/api_manager/test_resource_api_generation.py
+++ b/tests/api_manager/test_resource_api_generation.py
@@ -70,11 +70,6 @@ def test_generate_rest_api_routes(empty_api):
 
 @pytest.mark.unit
 def test_generate_saves_swagger_file(valid_base, empty_api, mocker):
-    mocker.patch("data_resource.generator.app.current_app")
-    static_folder = mocker.patch(
-        "data_resource.generator.app.get_static_folder_from_app"
-    )
-    static_folder.return_value = ""
     mocked_file = mocker.patch("data_resource.generator.app.open", mocker.mock_open())
     mocker.patch("os.path.join").return_value = "test"
 
@@ -93,7 +88,7 @@ def test_generate_serves_swagger_ui(valid_base, empty_api, mocker):
 
     start_data_resource_generator({"data": {}, "api": {"apiSpec": {}}}, {})
 
-    create_models.assert_called_once_with({})
+    create_models.assert_called_once_with({}, touch_database=True)
     generate_api.assert_called_once_with(
         api={}, base=None, swagger={}, relationships=[]
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import pytest
+import os
 from sqlalchemy.exc import OperationalError
 from sqlalchemy import inspect
 from data_resource import create_app
@@ -47,6 +48,11 @@ class Database:
 def empty_database():
     db = Database()
     db.destory_db()
+    yield
+    try:
+        os.remove("./static/data_resource_schema.json")
+    except:
+        pass
 
 
 @pytest.fixture


### PR DESCRIPTION
# Pull Request

## Description

https://app.clubhouse.io/brighthive/story/1248/drg-can-restart-safely

If a data resource schema file exists in the static folder, the application will load the ORM based on that file and not touch the database.

If the data resource schema file does not exist, the application will continue as normal. Once the generator route is called, the data resource schema file will be saved to the local file system and the database will be touched.

This allows the application to restart and be modified. In order to modify the application you will have to manually perform migrations to the database (ensuring it matches what the generated database should look like) and ensure your data resource schema correctly matches.

* Pin the table schema sql py version
* Pull static folder from Config Factory
* On startup, check for an existing data resource schema. Load ORM from that if exists.

## Checklists

### Basic

- [ ] Did you write tests for the code in this PR?
- [x] Did you document your changes in the README and/or in docstrings (as needed)?

### Security

- [ ] Authorization has been implemented across these changes
- [ ] Injection has been prevented (parameterized queries, no eval or system calls)
- [ ] Any web UI is escaping output (to prevent XSS)
- [ ] Sensitive data has been identified and is being protected properly

## Notes for the Reviewer

Logically this "deterministically" generates ORM regardless of what is in the database. It is unclear to me if there are problems this could introduce. For instance, if SQL Alchemy generates and saves sequences, are the same sequences being used with SQL Alchemy when the application restarts? These are similar problems with using SQL Alchemy database reflection -- 

https://docs.sqlalchemy.org/en/13/core/reflection.html#limitations-of-reflection
* Client side defaults, either Python functions or SQL expressions defined using the default keyword of Column (note this is separate from server_default, which specifically is what’s available via reflection). 
* Column information, e.g. data that might have been placed into the Column.info dictionary 
* The value of the .quote setting for Column or Table 
* The association of a particular Sequence with a given Column

----

This needs to be tested with docker-compose. Should work fine.