### PR TITLE
feat: Revert mn table names to DRA style.

### DIFF
--- a/data_resource/generator/model_manager/model_manager.py
+++ b/data_resource/generator/model_manager/model_manager.py
@@ -100,7 +100,7 @@ def construct_many_to_many_assoc(metadata: "MetaData", relationship: list) -> st
     relationship.sort()
 
     association = Table(
-        f"assoc_{relationship[0].lower()}_{relationship[1].lower()}",
+        f"{relationship[0].lower()}/{relationship[1].lower()}",
         metadata,
         Column(
             f"{relationship[0].lower()}_id",

--- a/tests/model_manager/test_many_to_many.py
+++ b/tests/model_manager/test_many_to_many.py
@@ -29,19 +29,19 @@ def test_create_mn_association_table():
     result = construct_many_to_many_assoc(metadata, many_to_many_relationships)
 
     # Returns the table name
-    assert result == "assoc_people_team"
-    assert "assoc_people_team" in metadata.tables
+    assert result == "people/team"
+    assert "people/team" in metadata.tables
     # The field has the correct foreign key
     try:
         assert "{ForeignKey('people.id')}" == str(
-            metadata.tables["assoc_people_team"].columns["people_id"].foreign_keys
+            metadata.tables["people/team"].columns["people_id"].foreign_keys
         )
     except KeyError:
         pytest.fail("KeyError: Column was probably not found.")
 
     try:
         assert "{ForeignKey('team.id')}" == str(
-            metadata.tables["assoc_people_team"].columns["team_id"].foreign_keys
+            metadata.tables["people/team"].columns["team_id"].foreign_keys
         )
     except KeyError:
         pytest.fail("KeyError: Column was probably not found.")
@@ -51,7 +51,7 @@ def test_create_mn_association_table():
 def test_automap_metadata_for_mn():
     metadata = MetaData()
     _ = Table(
-        "assoc_people_team",
+        "people/team",
         metadata,
         Column("people_id", Integer, ForeignKey("people.id"), primary_key=True),
         Column("team_id", Integer, ForeignKey("team.id"), primary_key=True),

--- a/tests/model_manager/test_model_manager.py
+++ b/tests/model_manager/test_model_manager.py
@@ -11,7 +11,7 @@ from data_resource.db.base import db_session
 def test_creates_all_required_tables(generated_e2e_database_inspector):
     tables = generated_e2e_database_inspector.get_table_names()
     tables.sort()
-    expected = ["required", "people", "order", "assoc_people_team", "team"]
+    expected = ["required", "people", "order", "people/team", "team"]
     expected.sort()
 
     assert tables == expected
@@ -29,7 +29,7 @@ def test_create_models_creates_all_required_orm(VALID_DATA_DICTIONARY, empty_dat
     assert "people" in metadata.tables
     assert "team" in metadata.tables
     assert "order" in metadata.tables
-    assert "assoc_people_team" in metadata.tables
+    assert "people/team" in metadata.tables
 
     # The auto mapped python classes exist
     assert base.classes.people


### PR DESCRIPTION
# Pull Request

## Description

- Reverts MN table naming convention to the style of DRA. Should be compatible out of the box with DRA as a result.

## Checklists

### Basic

- [x] Did you write tests for the code in this PR?
- [ ] Did you document your changes in the README and/or in docstrings (as needed)?

### Security

- [ ] Authorization has been implemented across these changes
- [ ] Injection has been prevented (parameterized queries, no eval or system calls)
- [ ] Any web UI is escaping output (to prevent XSS)
- [ ] Sensitive data has been identified and is being protected properly

## Notes for the Reviewer

A precise explanation of what the PR reviewer needs to evaluate. This might be:

* a low-level code review of certain functions
* a high-level assessment of strategy or architecture
* a confirmation that the code behaves as expected on another machine
