### PR TITLE
fix: Return a tables primary key value on create.

### DIFF
--- a/data_resource/generator/api_manager/v1_0_0/crud_functions/resource_create.py
+++ b/data_resource/generator/api_manager/v1_0_0/crud_functions/resource_create.py
@@ -3,6 +3,7 @@ from data_resource.db.base import db_session
 from flask import Request
 from data_resource.shared_utils.api_exceptions import ApiError
 from data_resource.shared_utils.log_factory import LogFactory
+from sqlalchemy.orm import class_mapper
 
 logger = LogFactory.get_console_logger("generator:resource-create")
 
@@ -24,46 +25,24 @@ class ResourceCreate:
             raise ApiError("No request body found.", 400)
 
         # Validate our schema? This should have already occured # TODO add test for do not let unvalidated tableschema in
-        # _ = Schema(table_schema)
-        # errors = []
-        # accepted_fields = []
-
-        # if not validate(table_schema):
-        # raise SchemaValidationFailure()
-        # raise
-
         # Check for required fields # Need tableschema to find required items... won't this be in the ORM? TODO check ORM for required? try except?
-        # for field in table_schema["fields"]:
-        # accepted_fields.append(field["name"])
-
-        # if field["required"] and not field["name"] in request_obj.keys():
-        # errors.append(f"Required field '{field['name']}' is missing.")
-
-        # valid_fields = []
-
-        # check if the value is in our tbl schema or assume its a many to many
-        # removed code
-
-        # TODO is it a security concern to destructure anything into sqlalchemy model?
         try:
             new_object = resource_orm()
             for key, value in request_obj.items():
-                setattr(new_object, key, value)
+                setattr(
+                    new_object, key, value
+                )  # TODO is it a security concern to destructure user given items into sqlalchemy model like this?
 
-            # try except here to catch errors? # TODO
             db_session.add(new_object)
             db_session.commit()
 
-            # Can we get primary key(s) from sqlalchemy model?
             # https://stackoverflow.com/questions/6745189/how-do-i-get-the-name-of-an-sqlalchemy-objects-primary-key
-            # id_value = getattr(new_object, table_schema["primaryKey"])
-            id_value = new_object.id  # TODO
+            pk_col = class_mapper(resource_orm).primary_key[0].name
+            pk_value = getattr(new_object, pk_col)
 
-            # if there are many to many items they need to be built in orm and processed here # TODO FIX
-
-            return {"message": "Successfully added new resource.", "id": id_value}, 201
+            return {"message": "Successfully added new resource.", "id": pk_value}, 201
         except Exception:
             # wrong type -- psycopg2.errors.InvalidTextRepresentation
             # IntegrityError('(psycopg2.errors.NotNullViolation) null value in column "required" violates not-null constraint\nDETAIL:  Failing row contains (1, null, 1).\n')
             db_session.rollback()
-            raise ApiError("Failed to create new resource.", 400)
+            raise ApiError(f"Failed to create new resource.", 400)


### PR DESCRIPTION
# Pull Request

## Description

When a resource is created the primary key values should be returned.

Previously the application just returned the value of 'id'.

This fixes that and returns the value of the first primary key.

TODO:
- [ ] get_one uses hard-coded `id` for look up


## Checklists

### Basic

- [ ] Did you write tests for the code in this PR?
- [ ] Did you document your changes in the README and/or in docstrings (as needed)?

### Security

- [ ] Authorization has been implemented across these changes
- [ ] Injection has been prevented (parameterized queries, no eval or system calls)
- [ ] Any web UI is escaping output (to prevent XSS)
- [ ] Sensitive data has been identified and is being protected properly

## Notes for the Reviewer

On success, should the API return the PK value in `id`? Or should it actually name it's primary key?

Perhaps `{"pk_value": 1, "pk_col": "id"}` is more appropriate?

The only thing is if the application is trying to verify it posted the correct item if the key changes with the model then the client will have to look up the pk col name which seems bad.
